### PR TITLE
Added platform path separator to trim for org replace

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
 		"test:unit-test": "jest",
 		"test:end-to-end": "node tests/tester.js",
 		"test": "npm run test:end-to-end && npm run test:unit-test",
+
 		"purge": "rimraf packages/*/node_modules | rimraf packages/*/dist | rimraf node_modules | rimraf packages/*/lib",
+
 		"build": "lerna bootstrap && lerna run build"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"test:end-to-end": "node tests/tester.js",
 		"test": "npm run test:end-to-end && npm run test:unit-test",
 
-		"purge": "rimraf packages/*/node_modules | rimraf packages/*/dist | rimraf node_modules | rimraf packages/*/lib",
+		"purge": "rimraf packages/*/node_modules | rimraf packages/*/dist | rimraf packages/*/lib | rimraf node_modules",
 
 		"build": "lerna bootstrap && lerna run build"
 	},

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"test:unit-test": "jest",
 		"test:end-to-end": "node tests/tester.js",
 		"test": "npm run test:end-to-end && npm run test:unit-test",
-
+		"purge": "rimraf packages/*/node_modules | rimraf packages/*/dist | rimraf node_modules | rimraf packages/*/lib",
 		"build": "lerna bootstrap && lerna run build"
 	},
 	"engines": {
@@ -21,7 +21,8 @@
 		"lerna": "^3.4.3",
 		"npm-run-all": "^4.1.2",
 		"onchange": "^3.2.1",
-		"replace-in-file": "^3.0.0"
+		"replace-in-file": "^3.0.0",
+		"rimraf": "^2.6.3"
 	},
 	"jest": {
 		"testEnvironment": "node",

--- a/packages/pancake-sass/src/sass.js
+++ b/packages/pancake-sass/src/sass.js
@@ -45,7 +45,10 @@ export const GetPath = ( module, modules, baseLocation, npmOrg ) => {
 	let location;
 	npmOrgs.forEach( org => {
 		if( baseLocation.includes( org ) ){
-			location = Path.posix.resolve( baseLocation.replace( `${ org }/`, '' ) ) + `/`;
+			location = baseLocation.replace( `${ org }`, '' );
+
+			// Hack to remove trailing / or \
+			location = location.replace( /[\\/]+$/, '' );
 		}
 	});
 

--- a/packages/pancake-sass/src/sass.js
+++ b/packages/pancake-sass/src/sass.js
@@ -44,7 +44,10 @@ export const GetPath = ( module, modules, baseLocation, npmOrg ) => {
 	const npmOrgs = npmOrg.split( ' ' );
 	let location;
 	npmOrgs.forEach( org => {
-		if( baseLocation.includes( org ) ){
+		if( baseLocation.includes( org ) && process.platform === 'win32' ){
+			location = baseLocation.replace( `${ org }\\`, '' );
+		}
+		else if( baseLocation.includes( org ) ){
 			location = baseLocation.replace( `${ org }/`, '' );
 		}
 	});

--- a/packages/pancake-sass/src/sass.js
+++ b/packages/pancake-sass/src/sass.js
@@ -44,11 +44,8 @@ export const GetPath = ( module, modules, baseLocation, npmOrg ) => {
 	const npmOrgs = npmOrg.split( ' ' );
 	let location;
 	npmOrgs.forEach( org => {
-		if( baseLocation.includes( org ) && process.platform === 'win32' ){
-			location = baseLocation.replace( `${ org }\\`, '' );
-		}
-		else if( baseLocation.includes( org ) ){
-			location = baseLocation.replace( `${ org }/`, '' );
+		if( baseLocation.includes( org ) ){
+			location = Path.posix.resolve( baseLocation.replace( `${ org }/`, '' ) ) + `/`;
 		}
 	});
 

--- a/packages/pancake-sass/src/sass.js
+++ b/packages/pancake-sass/src/sass.js
@@ -45,10 +45,7 @@ export const GetPath = ( module, modules, baseLocation, npmOrg ) => {
 	let location;
 	npmOrgs.forEach( org => {
 		if( baseLocation.includes( org ) ){
-			location = baseLocation.replace( `${ org }`, '' );
-
-			// Hack to remove trailing / or \
-			location = location.replace( /[\\/]+$/, '' );
+			location = baseLocation.replace( `${ org }${ Path.sep }`, '' );
 		}
 	});
 


### PR DESCRIPTION
Fix #94 
Resolves find and replacement issues on Windows where the org wasn't being trimmed leading to `@gov.au/@gov.au`

Also adds a `purge` script do delete intermediate files