### PR TITLE
Remove sass versioning by default

### DIFF
--- a/packages/pancake-sass/CHANGELOG.md
+++ b/packages/pancake-sass/CHANGELOG.md
@@ -6,6 +6,7 @@ Pancake Sass plugin
 
 ## Versions
 
+* [v2.3.5  - Remove sass-versioning](v235)
 * [v2.3.4  - Added cross-platform path seperator for org replace function](v234)
 * [v2.2.4  - Upgrade dependencies](v224)
 * [v2.1.4  - Reverted pathing issue with pancake-sass, corrected changelog](v214)
@@ -33,6 +34,11 @@ Pancake Sass plugin
 
 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+## v2.3.5
+
+- Remove sass-versioning
+
 
 ## v2.3.4
 

--- a/packages/pancake-sass/CHANGELOG.md
+++ b/packages/pancake-sass/CHANGELOG.md
@@ -37,7 +37,7 @@ Pancake Sass plugin
 
 ## v2.3.5
 
-- Remove sass-versioning
+- Remove sass-versioning import and version check
 
 
 ## v2.3.4

--- a/packages/pancake-sass/README.md
+++ b/packages/pancake-sass/README.md
@@ -58,6 +58,7 @@ To run the tests make sure you go to the monorepo this package came from and clo
 
 ## Release History
 
+* v2.3.5 - Remove sass-versioning
 * v2.3.4 - Added cross-platform path seperator for org replace function
 * v2.2.4 - Upgrade dependencies
 * v2.1.4 - Reverted pathing issue with pancake-sass, corrected changelog

--- a/packages/pancake-sass/package.json
+++ b/packages/pancake-sass/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gov.au/pancake-sass",
-	"version": "2.3.4",
+	"version": "2.3.5",
 	"description": "A Pancake plugin to compile sass files.",
 	"keywords": [
 		"npm",

--- a/packages/pancake-sass/src/pancake.js
+++ b/packages/pancake-sass/src/pancake.js
@@ -147,9 +147,7 @@ module.exports.pancake = ( version, modules, settings, GlobalSettings, cwd ) => 
 
 					sass = `${ banner }` +
 						`/* ${ modulePackage.name } v${ modulePackage.version } */\n\n` +
-						`@import "${ sassVersioningPath }";\n\n` +
-						`${ sass }\n` +
-						`@include versioning-check();\n`;
+						`${ sass }\n`
 				}
 				else {
 					sass = `/* ${ modulePackage.name } v${ modulePackage.version } */\n\n${ sass }\n`;


### PR DESCRIPTION
As we go through the process of deprecating `sass-versioning` we need to update the latest pancake release to not automatically import and run the `version-check()` mixin.

This PR will fail the tests until we update the fixtures...

## Example:

### Before:

```
/*! PANCAKE v1.3.1 PANCAKE-SASS v2.1.4 */

/*
 * THIS FILE IS AUTOGENERATED EVERY TIME YOU INSTALL A PANCAKE MODULE.
 * DO NOT EDIT THIS FILE AND AVOID COMMITTING IT TO VERSION CONTROL.
 */

@import "/path/to/sass-versioning/dist/_index.scss";

@import "path/to/_module.scss";
@include versioning-check();
```

### After:

```
/*! PANCAKE v1.3.1 PANCAKE-SASS v2.1.4 */

/*
 * THIS FILE IS AUTOGENERATED EVERY TIME YOU INSTALL A PANCAKE MODULE.
 * DO NOT EDIT THIS FILE AND AVOID COMMITTING IT TO VERSION CONTROL.
 */

@import "path/to/_module.scss";

```