### PR TITLE
Corrected find and replace path separator for Windows

### DIFF
--- a/packages/pancake-sass/CHANGELOG.md
+++ b/packages/pancake-sass/CHANGELOG.md
@@ -6,6 +6,7 @@ Pancake Sass plugin
 
 ## Versions
 
+* [v2.3.4  - Added cross-platform path seperator for org replace function](v234)
 * [v2.2.4  - Upgrade dependencies](v224)
 * [v2.1.4  - Reverted pathing issue with pancake-sass, corrected changelog](v214)
 * [v2.1.3  - Added cross-platform path seperator for org replace function](v213)
@@ -32,6 +33,11 @@ Pancake Sass plugin
 
 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+## v2.3.4
+
+- Added cross-platform path seperator for org replace function
+
 
 ## v2.2.4
 

--- a/packages/pancake-sass/README.md
+++ b/packages/pancake-sass/README.md
@@ -58,6 +58,7 @@ To run the tests make sure you go to the monorepo this package came from and clo
 
 ## Release History
 
+* v2.3.4 - Added cross-platform path seperator for org replace function
 * v2.2.4 - Upgrade dependencies
 * v2.1.4 - Reverted pathing issue with pancake-sass, corrected changelog
 * v2.1.3 - Added cross-platform path seperator for org replace function

--- a/packages/pancake-sass/package.json
+++ b/packages/pancake-sass/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gov.au/pancake-sass",
-	"version": "2.2.4",
+	"version": "2.3.4",
 	"description": "A Pancake plugin to compile sass files.",
 	"keywords": [
 		"npm",

--- a/packages/pancake-sass/src/sass.js
+++ b/packages/pancake-sass/src/sass.js
@@ -45,7 +45,7 @@ const GetPath = ( module, modules, baseLocation, npmOrg ) => {
 	let location;
 	npmOrgs.forEach( org => {
 		if( baseLocation.includes( org ) ){
-			location = baseLocation.replace( `${ org }/`, '' );
+			location = baseLocation.replace( `${ org }${ Path.sep }`, '' );
 		}
 	});
 


### PR DESCRIPTION
fixes #102 

We implemented this previously but removed it in a debugging step, this was never an issue and is a required fix to run pancake with sass on Windows.